### PR TITLE
Re-add --no-cache-dir to tensorflow Dockerfile

### DIFF
--- a/docker/tensorflow/Dockerfile
+++ b/docker/tensorflow/Dockerfile
@@ -57,7 +57,7 @@ RUN export uid=${HOST_UID} gid=${HOST_GID} && \
 
 
 RUN git clone https://github.com/mwydmuch/ViZDoom ${HOME_DIR}/vizdoom
-RUN pip3 install ${HOME_DIR}/vizdoom
+RUN pip3 install --no-cache-dir ${HOME_DIR}/vizdoom
 RUN pip3 install tensorflow-gpu
 RUN pip3 install matplotlib scipy scikit-image tqdm
 


### PR DESCRIPTION
In the archive from 2017 the Dockerfiles install the project with pip install --no-cache-dir ...
The lack of this causes the following error when building the image:

  [ 37%] Built target dumb
  Makefile:83: recipe for target 'all' failed
  make: *** [all] Error 2
  
  Installation failed, you may be missing some dependencies.
  Please check https://github.com/mwydmuch/ViZDoom/blob/master/doc/Building.md for details
  
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-req-build-aabreir7/setup.py", line 119, in <module>
      keywords=['vizdoom', 'doom', 'ai', 'deep learning', 'reinforcement learning', 'research']
    File "/usr/lib/python3.5/distutils/core.py", line 148, in setup
      dist.run_commands()
    File "/usr/lib/python3.5/distutils/dist.py", line 955, in run_commands
      self.run_command(cmd)
    File "/usr/lib/python3.5/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/usr/lib/python3/dist-packages/wheel/bdist_wheel.py", line 179, in run
      self.run_command('build')
    File "/usr/lib/python3.5/distutils/cmd.py", line 313, in run_command
      self.distribution.run_command(command)
    File "/usr/lib/python3.5/distutils/dist.py", line 974, in run_command
      cmd_obj.run()
    File "/tmp/pip-req-build-aabreir7/setup.py", line 82, in run
      subprocess.check_call(['make', '-j', str(cpu_cores)])
    File "/usr/lib/python3.5/subprocess.py", line 581, in check_call
      raise CalledProcessError(retcode, cmd)
  subprocess.CalledProcessError: Command '['make', '-j', '3']' returned non-zero exit status 2
  
  ----------------------------------------
  Running setup.py clean for vizdoom