### PR TITLE
Update learning_stable_baselines.py (frame_skip error)

### DIFF
--- a/examples/python/learning_stable_baselines.py
+++ b/examples/python/learning_stable_baselines.py
@@ -53,6 +53,7 @@ class ObservationWrapper(gym.ObservationWrapper):
         super().__init__(env)
         self.image_shape = shape
         self.image_shape_reverse = shape[::-1]
+        self.frame_skip = FRAME_SKIP
 
         # Create new observation space with the new shape
         num_channels = env.observation_space["rgb"].shape[-1]


### PR DESCRIPTION
Hey there :wave:  ,

There is an error in the stable baselines 3 vizdoom example.
We defined FRAME_SKIP=4 but we never use it. So it takes the default value (1).

Have a nice day :hugs: 