### PR TITLE
Fix build issue when building with CMake 3.25 and Boost 1.70

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ class BuildCommand(build):
             cpu_cores = max(1, cpu_count() - 1)
             python_executable = os.path.realpath(sys.executable)
 
-            cmake_arg_list = ["cmake", "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_PYTHON=ON",
+            cmake_arg_list = ["cmake", "-DCMAKE_BUILD_TYPE=Release", "-DBUILD_PYTHON=ON", "-DBoost_NO_BOOST_CMAKE=ON",  
                               "-DPYTHON_EXECUTABLE={}".format(python_executable)]
                               
             if platform.startswith("win"):


### PR DESCRIPTION
This is the fix the the issue #517 

According to the boost 1.70 build issue with cmake [https://github.com/lightspark/lightspark/issues/344](https://github.com/lightspark/lightspark/issues/344), one way to fix this is to maunnally enable the option for cmake to realize boost ([reference](https://github.com/lightspark/lightspark/issues/344#issuecomment-485589894)): `-DBoost_NO_BOOST_CMAKE=ON`

I added that and rebuilt it successfully.