### PR TITLE
Revert pyright to the previous version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,6 +74,6 @@ repos:
         language: node
         pass_filenames: false
         types: [python]
-        additional_dependencies: ["pyright"]
+        additional_dependencies: ["pyright@1.1.347"]
         args:
           - --project=pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ reportMissingImports = "none"
 reportGeneralTypeIssues = "none"
 reportPrivateUsage = "warning"
 reportPrivateImportUsage = "warning"
+reportAttributeAccessIssue = "warning"
 
 [tool.cibuildwheel]
 # We need to build for the following Python versions:


### PR DESCRIPTION
This is a hotfix that aims to fix pre-commit checks that fail when using a new pyright 1.1.350 version.