### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/src/vizdoom/bzip2/decompress.c
+++ b/src/vizdoom/bzip2/decompress.c
@@ -287,7 +287,7 @@ Int32 BZ2_decompress ( DState* s )
       GET_BITS(BZ_X_SELECTOR_1, nGroups, 3);
       if (nGroups < 2 || nGroups > 6) RETURN(BZ_DATA_ERROR);
       GET_BITS(BZ_X_SELECTOR_2, nSelectors, 15);
-      if (nSelectors < 1) RETURN(BZ_DATA_ERROR);
+      if (nSelectors < 1 || nSelectors > BZ_MAX_SELECTORS) RETURN(BZ_DATA_ERROR);
       for (i = 0; i < nSelectors; i++) {
          j = 0;
          while (True) {


### PR DESCRIPTION
Hi Development Team,

I identified a potential vulnerability in a clone function BZ2_decompress() in `src/vizdoom/bzip2/decompress.c` sourced from [federicomenaquintero/bzip2](https://gitlab.com/federicomenaquintero/bzip2). This issue, originally reported in [CVE-2019-12900](https://nvd.nist.gov/vuln/detail/CVE-2019-12900), was resolved in the repository via this commit [federicomenaquintero/bzip2@74de1e2](https://gitlab.com/federicomenaquintero/bzip2/-/commit/74de1e2e6ffc9d51ef9824db71a8ffee5962cdbc#951eb5324dc64ed8c9225bfcdcb72ee7a3932918).

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you!