### PR TITLE
[Benchmark] Benchmarking the VizDoom env in vectorized gymnasium

### DIFF
--- a/examples/python/gymnasium_vect_bench.py
+++ b/examples/python/gymnasium_vect_bench.py
@@ -20,21 +20,24 @@ args = parser.parse_args()
 seed = 42
 n_steps = 1000
 
-# Pick an environment VizdoomCorridor-v0
-envs = gymnasium.make_vec(
-    "VizdoomCorridor-v0", num_envs=args.n_envs, vectorization_mode=args.mode
-)
 
-# Time it
-start = time.time()
+if __name__ == "__main__":
 
-observation, info = envs.reset()
-for _ in range(n_steps):
-    # No learning here, for purposes of benchmarks
-    actions = envs.action_space.sample()
-    observations, rewards, terminations, truncations, infos = envs.step(actions)
-    # env reset here slows it down
-    # if terminated or truncated:
-    #    observation, info = env.reset()
-print(f"{args.n_envs}  {n_steps *args.n_envs /round(time.time() - start,1)}")
-envs.close()
+    # Pick an environment VizdoomCorridor-v0
+    envs = gymnasium.make_vec(
+        "VizdoomCorridor-v0", num_envs=args.n_envs, vectorization_mode=args.mode
+    )
+
+    # Time it
+    start = time.time()
+
+    observation, info = envs.reset()
+    for _ in range(n_steps):
+        # No learning here, for purposes of benchmarks
+        actions = envs.action_space.sample()
+        observations, rewards, terminations, truncations, infos = envs.step(actions)
+        # no need for env.reset() here since the default is AutoReset(https://farama.org/Vector-Autoreset-Mode)
+        # if terminated or truncated:
+        #    observation, info = env.reset()
+    print(f"{args.n_envs}  {n_steps *args.n_envs /round(time.time() - start,1)}")
+    envs.close()

--- a/examples/python/gymnasium_vect_bench.py
+++ b/examples/python/gymnasium_vect_bench.py
@@ -1,24 +1,28 @@
 #####################################################################
 # Test and benchmark the vectorization of VizDoom in gymnasium
 #####################################################################
-
 import argparse
 import time
 import warnings
 
 import gymnasium
 
+from vizdoom import gymnasium_wrapper  # noqa
+
 
 warnings.filterwarnings("ignore")
 parser = argparse.ArgumentParser()
 parser.add_argument("--n_envs", type=int, default=1, help="Number of envs")
+parser.add_argument(
+    "--mode", type=str, default="async", help="Gymnasium vectorization mode"
+)
 args = parser.parse_args()
 seed = 42
 n_steps = 1000
 
 # Pick an environment VizdoomCorridor-v0
 envs = gymnasium.make_vec(
-    "VizdoomCorridor-v0", num_envs=args.n_envs, vectorization_mode="async"
+    "VizdoomCorridor-v0", num_envs=args.n_envs, vectorization_mode=args.mode
 )
 
 # Time it

--- a/examples/python/gymnasium_vect_bench.py
+++ b/examples/python/gymnasium_vect_bench.py
@@ -1,26 +1,25 @@
-#!/usr/bin/env python3
-
 #####################################################################
 # Test and benchmark the vectorization of VizDoom in gymnasium
 #####################################################################
 
-import time
 import argparse
+import time
 import warnings
 
-from gymnasium.vector import AsyncVectorEnv
 import gymnasium
-from vizdoom import gymnasium_wrapper
+
 
 warnings.filterwarnings("ignore")
 parser = argparse.ArgumentParser()
-parser.add_argument("--n_envs", type =int, default = 1, help ="Number of envs")
-args =parser.parse_args()
+parser.add_argument("--n_envs", type=int, default=1, help="Number of envs")
+args = parser.parse_args()
 seed = 42
 n_episodes = 1000
 
 # Pick an environment VizdoomCorridor-v0
-envs = gymnasium.make_vec("VizdoomCorridor-v0", num_envs =args.n_envs, vectorization_mode="async")
+envs = gymnasium.make_vec(
+    "VizdoomCorridor-v0", num_envs=args.n_envs, vectorization_mode="async"
+)
 
 # Time it
 start = time.time()
@@ -30,7 +29,7 @@ for _ in range(n_episodes):
     # No learning here, for purposes of benchmarks
     actions = envs.action_space.sample()
     observations, rewards, terminations, truncations, infos = envs.step(actions)
-    # env reset here slows it down 
+    # env reset here slows it down
     # if terminated or truncated:
     #    observation, info = env.reset()
 print(f"{args.n_envs}  {n_episodes *args.n_envs /round(time.time() - start,1)}")

--- a/examples/python/gymnasium_vect_bench.py
+++ b/examples/python/gymnasium_vect_bench.py
@@ -14,7 +14,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--n_envs", type=int, default=1, help="Number of envs")
 args = parser.parse_args()
 seed = 42
-n_episodes = 1000
+n_steps = 1000
 
 # Pick an environment VizdoomCorridor-v0
 envs = gymnasium.make_vec(
@@ -25,12 +25,12 @@ envs = gymnasium.make_vec(
 start = time.time()
 
 observation, info = envs.reset()
-for _ in range(n_episodes):
+for _ in range(n_steps):
     # No learning here, for purposes of benchmarks
     actions = envs.action_space.sample()
     observations, rewards, terminations, truncations, infos = envs.step(actions)
     # env reset here slows it down
     # if terminated or truncated:
     #    observation, info = env.reset()
-print(f"{args.n_envs}  {n_episodes *args.n_envs /round(time.time() - start,1)}")
+print(f"{args.n_envs}  {n_steps *args.n_envs /round(time.time() - start,1)}")
 envs.close()

--- a/examples/python/gymnasium_vect_bench.py
+++ b/examples/python/gymnasium_vect_bench.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+#####################################################################
+# Test and benchmark the vectorization of VizDoom in gymnasium
+#####################################################################
+
+import time
+import argparse
+import warnings
+
+from gymnasium.vector import AsyncVectorEnv
+import gymnasium
+from vizdoom import gymnasium_wrapper
+
+warnings.filterwarnings("ignore")
+parser = argparse.ArgumentParser()
+parser.add_argument("--n_envs", type =int, default = 1, help ="Number of envs")
+args =parser.parse_args()
+seed = 42
+n_episodes = 1000
+
+# Pick an environment VizdoomCorridor-v0
+envs = gymnasium.make_vec("VizdoomCorridor-v0", num_envs =args.n_envs, vectorization_mode="async")
+
+# Time it
+start = time.time()
+
+observation, info = envs.reset()
+for _ in range(n_episodes):
+    # No learning here, for purposes of benchmarks
+    actions = envs.action_space.sample()
+    observations, rewards, terminations, truncations, infos = envs.step(actions)
+    # env reset here slows it down 
+    # if terminated or truncated:
+    #    observation, info = env.reset()
+print(f"{args.n_envs}  {n_episodes *args.n_envs /round(time.time() - start,1)}")
+envs.close()


### PR DESCRIPTION

Gymnasium offers SyncVect and AsyncVect (plus custom as well) environments. We would like to benchmark the VizDoom within such environments.

This is motivated by this paper, [ https://arxiv.org/abs/2407.17032]( https://arxiv.org/abs/2407.17032). In this paper the authors compare simple and complex environments. Looking at the plot below from the paper for a complex environment (Lunar Lander):

![Screenshot 2025-06-23 082925](https://github.com/user-attachments/assets/fe24fda0-98e8-4b9a-9d26-cd3f6716e4eb)

So here I kinda reproduce the left plot on my desktop computer with the following specs:
Intel(R) Core(TM) i5-7500 CPU @ 3.40GHz
32G RAM

And here is the plot I was able to produce:

![Screenshot 2025-06-30 113949](https://github.com/user-attachments/assets/697dda59-a254-42a2-b0fe-49b422a92c0e)
[UPDATED] included the data point at only 1 environment @mwydmuch.


It would be also interesting to test it also for better/slower machines as well.

So my conclusion is that Async in VizDoom is able to be faster than sync because of the availability of RAM (I think even higher RAM would give a boost in number of steps/s).
