### PR TITLE
Small patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ The main changes include/will include:
 - The update of Gymnasium environments to the latest Gymnasium API, and some minor improvements and bug fixes,
 - New version of the old environments and completely new environments,
 - New features including methods for easy setting of shaping reward, and natual language log of the game events,
-- Python 3.13 support.
+- Python 3.13 support,
+- Python type hinting support.
 
 To install the latest development version of ViZDoom, just run:
 ```sh
@@ -126,7 +127,7 @@ In this case, install the required dependencies using Homebrew:
 brew install cmake boost sdl2
 ```
 We recommend using at least macOS High Sierra 10.13+ with Python 3.8+.
-On Apple Silicon (M1, M2, and M3), make sure you are using Python/Pip for Apple Silicon.
+On Apple Silicon (M-series chips), make sure you are using Python/Pip for Apple Silicon.
 
 
 ### Windows

--- a/docs/introduction/apis_and_wrappers.md
+++ b/docs/introduction/apis_and_wrappers.md
@@ -35,7 +35,7 @@ and implements the necessary API to function as a Gymnasium API.
 
 See the following examples for use:
 - [examples/python/gymnasium_wrapper.py](https://github.com/Farama-Foundation/ViZDoom/tree/master/examples/python/gymnasium_wrapper.py) for basic usage
-- [examples/python/learning_stable_baselines.py](https://github.com/Farama-Foundation/ViZDoom/tree/master/examples/python/learning_stable_baselines.py) for example training with [stable-baselines3](https://github.com/DLR-RM/stable-baselines3/).
+- [examples/python/learning_stable_baselines.py](https://github.com/Farama-Foundation/ViZDoom/tree/master/examples/python/learning_stable_baselines3.py) for example training with [stable-baselines3](https://github.com/DLR-RM/stable-baselines3/).
 
 
 ## OpenAI Gym wrappers

--- a/examples/python/gymnasium_vect_bench.py
+++ b/examples/python/gymnasium_vect_bench.py
@@ -23,9 +23,9 @@ n_steps = 1000
 
 if __name__ == "__main__":
 
-    # Pick an environment VizdoomCorridor-v0
+    # Pick an environment VizdoomCorridor-v1
     envs = gymnasium.make_vec(
-        "VizdoomCorridor-v0", num_envs=args.n_envs, vectorization_mode=args.mode
+        "VizdoomCorridor-v1", num_envs=args.n_envs, vectorization_mode=args.mode
     )
 
     # Time it

--- a/examples/python/gymnasium_wrapper.py
+++ b/examples/python/gymnasium_wrapper.py
@@ -11,7 +11,7 @@ from vizdoom import gymnasium_wrapper  # noqa
 
 if __name__ == "__main__":
     env = gymnasium.make(
-        "VizdoomHealthGatheringSupreme-v0", render_mode="human", frame_skip=4
+        "VizdoomHealthGatheringSupreme-v1", render_mode="human", frame_skip=4
     )
 
     # Rendering random rollouts for ten episodes

--- a/gymnasium_wrapper/base_gymnasium_env.py
+++ b/gymnasium_wrapper/base_gymnasium_env.py
@@ -204,8 +204,9 @@ class VizdoomEnv(gym.Env, EzPickle):
         options: Optional[dict] = None,
     ):
         super().reset(seed=seed)
-        if seed is not None:
-            self.game.set_seed(seed)
+        # Ensure the game is seeded for reproducibility
+        if self._np_random_seed is not None:
+            self.game.set_seed(self._np_random_seed)
         self.game.new_episode()
         self.state = self.game.get_state()
 

--- a/src/lib_python/generate_vizdoom_stubs.py
+++ b/src/lib_python/generate_vizdoom_stubs.py
@@ -124,6 +124,8 @@ class ViZDoomStubGenerator:
         if os.path.exists(stub_file):
             with open(stub_file, "r") as f:
                 content = f.read().removeprefix('"""\nViZDoom Python module.\n"""\n')
+            # Remove exact value of __version__ from the stub to avoid misguiding the user
+            content = re.sub(r"^(__version__: str).*$", r"\1", content, count=1, flags=re.MULTILINE)
             return content
         else:
             raise FileNotFoundError(

--- a/src/lib_python/vizdoom.pyi
+++ b/src/lib_python/vizdoom.pyi
@@ -2815,4 +2815,4 @@ WEAPON8: GameVariable  # value = <GameVariable.WEAPON8: 35>
 WEAPON9: GameVariable  # value = <GameVariable.WEAPON9: 36>
 WHOLE: AutomapMode  # value = <AutomapMode.WHOLE: 1>
 ZOOM: Button  # value = <Button.ZOOM: 7>
-__version__: str = "1.3.0.dev2"
+__version__: str


### PR DESCRIPTION
@mwydmuch As discussed in https://github.com/Farama-Foundation/ViZDoom/pull/624, the minor changes / bug fixes:
- [Doc] Broken link to already renamed https://github.com/Farama-Foundation/ViZDoom/tree/master/examples/python/learning_stable_baselines.py
- [Gym] Fixed non-deterministic seeding behaviour when `seed=None` (which broke tests a few times previously), now behavior should align with gymnasium and `tests/test_gymnasium_wrapper.py`'s design
- [Example] Bumped deprecated `v0` gymnasium environments to `v1` so that examples can actually run
- [Example] In `examples/python/learning_stable_baselines3.py`, removed the unconventional `self.env.frame_skip = FRAME_SKIP` assignment at `ObservationWrapper.__init__` in favor of passing `frame_skip` into environment constructor: `env_kwargs=dict(frame_skip=FRAME_SKIP)`, also enabled progress bar when available.
- [Typing] Removed specific value for `__version__` in type stub since it would be misguiding for the user
- [README] Added a line `- Python type hinting support` and changed `M1, M2 and M3` to `M-series chips`