### PR TITLE
[Github Actions] Fix 7z version to 25.00 for installing boost

### DIFF
--- a/.github/workflows/build-and-test-windows-wheels.yml
+++ b/.github/workflows/build-and-test-windows-wheels.yml
@@ -69,8 +69,9 @@ jobs:
       id: cache-7z
       uses: actions/cache@v4
       with:
-        path: C:\Program Files\7-Zip
-        path: C:\ProgramData\chocolatey\lib\7zip
+        path: |
+          C:\Program Files\7-Zip
+          C:\ProgramData\chocolatey\lib\7zip
         key: 7zip-25.0-${{ runner.os }}
 
     - name: Install 7-Zip 25.00 for compatibility

--- a/.github/workflows/build-and-test-windows-wheels.yml
+++ b/.github/workflows/build-and-test-windows-wheels.yml
@@ -65,6 +65,9 @@ jobs:
         repository: mwydmuch/ViZDoomWinDepBin
         path: ${{ github.workspace }}\deps
 
+    - name: Force install 7-Zip 25.00 for MarkusJx/install-boost compatibility
+      run: choco install 7zip --version=25.0 -y --force
+
     - name: Install boost
       uses: MarkusJx/install-boost@v1.0.1
       id: install-boost

--- a/.github/workflows/build-and-test-windows-wheels.yml
+++ b/.github/workflows/build-and-test-windows-wheels.yml
@@ -65,8 +65,15 @@ jobs:
         repository: mwydmuch/ViZDoomWinDepBin
         path: ${{ github.workspace }}\deps
 
-    - name: Force install 7-Zip 25.00 for MarkusJx/install-boost compatibility
-      run: choco install 7zip --version=25.0 -y --force
+    - name: Cache 7-Zip
+      uses: actions/cache@v4
+      with:
+        path: C:\Program Files\7-Zip
+        key: 7zip-25.0
+
+    - name: Install 7-Zip 25.00 for compatibility
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: choco install 7zip --version=25.0 -y --force --allow-downgrade
 
     - name: Install boost
       uses: MarkusJx/install-boost@v1.0.1

--- a/.github/workflows/build-and-test-windows-wheels.yml
+++ b/.github/workflows/build-and-test-windows-wheels.yml
@@ -66,13 +66,14 @@ jobs:
         path: ${{ github.workspace }}\deps
 
     - name: Cache 7-Zip
+      id: cache-7z
       uses: actions/cache@v4
       with:
         path: C:\Program Files\7-Zip
         key: 7zip-25.0
 
     - name: Install 7-Zip 25.00 for compatibility
-      if: steps.cache.outputs.cache-hit != 'true'
+      if: steps.cache-7z.outputs.cache-hit != 'true'
       run: choco install 7zip --version=25.0 -y --force --allow-downgrade
 
     - name: Install boost

--- a/.github/workflows/build-and-test-windows-wheels.yml
+++ b/.github/workflows/build-and-test-windows-wheels.yml
@@ -70,10 +70,11 @@ jobs:
       uses: actions/cache@v4
       with:
         path: C:\Program Files\7-Zip
-        key: 7zip-25.0
+        path: C:\ProgramData\chocolatey\lib\7zip
+        key: 7zip-25.0-${{ runner.os }}
 
     - name: Install 7-Zip 25.00 for compatibility
-      if: steps.cache-7z.outputs.cache-hit != 'true'
+      if: steps.cache.outputs.cache-hit != 'true'
       run: choco install 7zip --version=25.0 -y --force --allow-downgrade
 
     - name: Install boost


### PR DESCRIPTION
Fixes https://github.com/Farama-Foundation/ViZDoom/pull/628
@mwydmuch I've tested on my fork that this indeed fixes issue associated with 7z 25.01 security update.
https://github.com/Trenza1ore/ViZDoom-Contrib/actions/runs/16854707236

Feel free to rename this step before merging it if name is undesirable. 😉 