### PR TITLE
[Github Actions] Disable CMake `POLICY CMP0167 NEW` behaviour when Boost version < 1.70

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,14 @@ if(POLICY CMP0003)
 endif()
 
 if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 NEW)
+  find_package(Boost 1.70 QUIET CONFIG)
+  if(Boost_FOUND)
+    cmake_policy(SET CMP0167 NEW)
+  else()
+    cmake_policy(SET CMP0167 OLD)
+  endif()
+  unset(Boost_FOUND CACHE)
+  unset(Boost_DIR CACHE)
 endif()
 
 # Add cmake_modules to module


### PR DESCRIPTION
Fixes the new error in manylinux wheel-building after https://github.com/Farama-Foundation/ViZDoom/pull/628
Boost < 1.70 may not ship with the config file required by `POLICY CMP0167`, and `1.66.0-13.el8` was used for building the manylinux wheel.
@mwydmuch 