### PR TITLE
Remove system component for Boost version 1.89+

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -61,6 +61,7 @@ jobs:
       if: runner.os == 'macOS'
       run: |
         brew config
+        brew uninstall cmake
         brew install cmake boost openal-soft sdl2
 
     - name: Set up Python ${{ matrix.python-version }} environment

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,11 @@ set(VIZDOOM_LIB_SRC_DIR ${VIZDOOM_SRC_DIR}/lib)
 set(VIZDOOM_LIB_INCLUDE_DIR ${VIZDOOM_INCLUDE_DIR} ${VIZDOOM_LIB_SRC_DIR})
 set(VIZDOOM_OUTPUT_NAME vizdoom)
 
-find_package(Boost 1.53 COMPONENTS filesystem thread system date_time chrono regex iostreams REQUIRED)
+if(Boost_VERSION VERSION_LESS 1.89)
+    find_package(Boost 1.56 COMPONENTS filesystem thread system date_time chrono regex iostreams REQUIRED)
+else()
+    find_package(Boost 1.89 COMPONENTS filesystem thread date_time chrono regex iostreams REQUIRED)
+endif()
 find_package(Threads REQUIRED)
 
 include_directories(${VIZDOOM_LIB_INCLUDE_DIR} ${Boost_INCLUDE_DIR})

--- a/src/lib/ViZDoomController.h
+++ b/src/lib/ViZDoomController.h
@@ -50,7 +50,6 @@ namespace vizdoom {
     namespace ba        = boost::asio;
     namespace bip       = boost::interprocess;
     namespace br        = boost::random;
-    namespace bs        = boost::system;
     namespace bpr       = boost::process;
     namespace bpri      = boost::process::initializers;
 

--- a/src/vizdoom/src/CMakeLists.txt
+++ b/src/vizdoom/src/CMakeLists.txt
@@ -387,7 +387,11 @@ endif( BACKPATCH )
 
 # Libraries ZDoom needs
 
-find_package(Boost COMPONENTS thread system date_time chrono REQUIRED)
+if(Boost_VERSION VERSION_LESS 1.89)
+	find_package(Boost 1.56 COMPONENTS thread system date_time chrono REQUIRED)
+else()
+	find_package(Boost 1.89 COMPONENTS thread date_time chrono REQUIRED)
+endif()
 
 message( STATUS "Fluid synth libs: ${FLUIDSYNTH_LIBRARIES}" )
 set( ZDOOM_LIBS ${ZDOOM_LIBS} "${ZLIB_LIBRARIES}" "${JPEG_LIBRARIES}" "${BZIP2_LIBRARIES}" "${GME_LIBRARIES}"  ${Boost_LIBRARIES} )


### PR DESCRIPTION
The system component of boost seems to have become a header-only library and was removed from the list of components in version 1.89.