### PR TITLE
Drop wheels building for Intel macOS

### DIFF
--- a/.github/workflows/build-and-test-wheels.yml
+++ b/.github/workflows/build-and-test-wheels.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-15, macos-15-intel]
+        os: [ubuntu-24.04, macos-14, macos-14-large]
       fail-fast: false
 
     steps:
@@ -56,7 +56,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
 
       - name: Build macOS Intel wheels
-        if: matrix.os == 'macos-15-intel'
+        if: matrix.os == 'macos-14-large'
         uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_ARCHS_MACOS: x86_64
@@ -64,7 +64,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
 
       - name: Build macOS Apple Silicon wheels
-        if: matrix.os == 'macos-15'
+        if: matrix.os == 'macos-14'
         uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_ARCHS_MACOS: arm64
@@ -87,7 +87,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-15-intel]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-14-large, macos-15-intel, macos-15]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
 
@@ -127,7 +127,7 @@ jobs:
         run: sudo apt install -y libopenal-dev
 
       - name: Install macOS Intel wheel on ${{ matrix.os }}
-        if: matrix.os == 'macos-15-intel'
+        if: matrix.os == 'macos-14-large' || matrix.os == 'macos-15-intel'
         run: |
           export PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
           export WHEEL=$(ls dist/vizdoom*cp${PYTHON_VERSION}*macosx*x86_64.whl)

--- a/.github/workflows/build-and-test-wheels.yml
+++ b/.github/workflows/build-and-test-wheels.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14, macos-14-large]
+        os: [ubuntu-24.04, macos-14]
       fail-fast: false
 
     steps:
@@ -55,14 +55,6 @@ jobs:
           CIBW_ARCHS_LINUX: x86_64 aarch64
           CIBW_BUILD_VERBOSITY: 1
 
-      - name: Build macOS Intel wheels
-        if: matrix.os == 'macos-14-large'
-        uses: pypa/cibuildwheel@v2.23.3
-        env:
-          CIBW_ARCHS_MACOS: x86_64
-          CIBW_ENVIRONMENT_MACOS: VIZDOOM_MACOS_ARCH=x86_64 HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 MACOSX_DEPLOYMENT_TARGET=14.0
-          CIBW_BUILD_VERBOSITY: 1
-
       - name: Build macOS Apple Silicon wheels
         if: matrix.os == 'macos-14'
         uses: pypa/cibuildwheel@v2.23.3
@@ -87,7 +79,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-14-large, macos-15-intel, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
 
@@ -125,13 +117,6 @@ jobs:
       - name: Install OpenAL on Ubuntu
         if: runner.os == 'Linux'
         run: sudo apt install -y libopenal-dev
-
-      - name: Install macOS Intel wheel on ${{ matrix.os }}
-        if: matrix.os == 'macos-14-large' || matrix.os == 'macos-15-intel'
-        run: |
-          export PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
-          export WHEEL=$(ls dist/vizdoom*cp${PYTHON_VERSION}*macosx*x86_64.whl)
-          python -m pip install ${WHEEL}[test]
 
       - name: Install macOS Apple Silicon wheel on ${{ matrix.os }}
         if: matrix.os == 'macos-14' || matrix.os == 'macos-15'

--- a/.github/workflows/build-and-test-wheels.yml
+++ b/.github/workflows/build-and-test-wheels.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-24.04, macos-15, macos-15-intel]
       fail-fast: false
 
     steps:
@@ -56,15 +56,15 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
 
       - name: Build macOS Intel wheels
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-15-intel'
         uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_ARCHS_MACOS: x86_64
-          CIBW_ENVIRONMENT_MACOS: VIZDOOM_MACOS_ARCH=x86_64 HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 MACOSX_DEPLOYMENT_TARGET=13.0
+          CIBW_ENVIRONMENT_MACOS: VIZDOOM_MACOS_ARCH=x86_64 HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 MACOSX_DEPLOYMENT_TARGET=14.0
           CIBW_BUILD_VERBOSITY: 1
 
       - name: Build macOS Apple Silicon wheels
-        if: matrix.os == 'macos-14'
+        if: matrix.os == 'macos-15'
         uses: pypa/cibuildwheel@v2.23.3
         env:
           CIBW_ARCHS_MACOS: arm64
@@ -87,7 +87,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-15-intel]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: false
 
@@ -127,14 +127,14 @@ jobs:
         run: sudo apt install -y libopenal-dev
 
       - name: Install macOS Intel wheel on ${{ matrix.os }}
-        if: matrix.os == 'macos-12' || matrix.os == 'macos-13'
+        if: matrix.os == 'macos-15-intel'
         run: |
           export PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
           export WHEEL=$(ls dist/vizdoom*cp${PYTHON_VERSION}*macosx*x86_64.whl)
           python -m pip install ${WHEEL}[test]
 
       - name: Install macOS Apple Silicon wheel on ${{ matrix.os }}
-        if: matrix.os == 'macos-14'
+        if: matrix.os == 'macos-14' || matrix.os == 'macos-15'
         run: |
           export PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
           export WHEEL=$(ls dist/vizdoom*cp${PYTHON_VERSION}*macosx*arm64.whl)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
     name: Build and test on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15-intel]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: true
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,7 +34,7 @@ jobs:
     name: Build and test on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15-intel]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
       fail-fast: true
     runs-on: ${{ matrix.os }}

--- a/src/vizdoom/src/posix/sdl/hardware.cpp
+++ b/src/vizdoom/src/posix/sdl/hardware.cpp
@@ -90,7 +90,7 @@ void I_InitGraphics ()
 		Printf("Using video driver %s\n", SDL_GetCurrentVideoDriver());
 	}
 	else
-		Printf("Not using any video driver. Check-mate GUI believers!\n");
+		Printf("Not using any video driver.\n");
 	UCVarValue val;
 
 	val.Bool = !!Args->CheckParm ("-devparm");

--- a/src/vizdoom/src/posix/sdl/i_main.cpp
+++ b/src/vizdoom/src/posix/sdl/i_main.cpp
@@ -203,9 +203,6 @@ int main (int argc, char **argv)
 		cc_install_handlers(argc, argv, 4, s, GAMENAMELOWERCASE "-crash.log", DoomSpecificInfo);
 	}
 #endif // !__APPLE__
-
-	//I'm not proud of this solution. Shame on me.
-
 	//VIZDOOM_CODE
 	for(int i = 0; i < argc; ++i){
 		if(strcmp("+viz_noconsole", argv[i]) == 0) {


### PR DESCRIPTION
This PR remove `macos-13` Intel runners from the workflows including one that build wheels for Intel during release.