### PR TITLE
Disable Gymnasium wrapper tests in some workflows

### DIFF
--- a/.github/workflows/build-and-test-wheels.yml
+++ b/.github/workflows/build-and-test-wheels.yml
@@ -15,7 +15,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/build-and-test-wheels.yml'
-      branches: [master]
+    branches: [master]
   release:
     types: [published]
 

--- a/.github/workflows/build-and-test-wheels.yml
+++ b/.github/workflows/build-and-test-wheels.yml
@@ -15,6 +15,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/build-and-test-wheels.yml'
+      branches: [master]
   release:
     types: [published]
 
@@ -136,7 +137,7 @@ jobs:
         run: python -c "import vizdoom"
 
       - name: Run tests
-        run: pytest tests -s
+        run: pytest tests -s --ignore=tests/test_gymnasium_wrapper.py  # Skip gymnasium wrapper tests as they are tested in a separate workflow and take a long time to run
 
   build_sdist:
     name: Build source distribution

--- a/.github/workflows/build-and-test-windows-wheels.yml
+++ b/.github/workflows/build-and-test-windows-wheels.yml
@@ -22,6 +22,7 @@ on:
       - 'CMakeLists.txt'
       - 'setup.py'
       - 'pyproject.toml'
+    branches: [master]
   release:
     types: [published]
 
@@ -193,8 +194,7 @@ jobs:
         run: python -c "import vizdoom; g = vizdoom.DoomGame(); g.set_window_visible(False); g.set_console_enabled(True); g.set_sound_enabled(True); g.init()"
 
       - name: Run test
-        run: |
-          python -m pytest tests
+        run: python -m pytest tests -s --ignore=tests/test_gymnasium_wrapper.py  # Skip gymnasium wrapper tests as they are tested in a separate workflow and take a long time to run
 
 
   upload_pypi:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -90,4 +90,4 @@ jobs:
       run: python -c "import vizdoom; g = vizdoom.DoomGame(); g.set_window_visible(False); g.set_console_enabled(True); g.set_audio_buffer_enabled(True); g.add_game_args('+snd_efx 0'); g.init()"
 
     - name: Run tests
-      run: pytest tests -s
+      run: pytest tests -s --ignore=tests/test_gymnasium_wrapper.py  # Skip gymnasium wrapper tests as they are tested in a separate workflow and take a long time to run

--- a/.github/workflows/test-gymnasium-wrapper.yml
+++ b/.github/workflows/test-gymnasium-wrapper.yml
@@ -5,7 +5,9 @@ on:
     paths:
       - '.github/workflows/test-gymnasium-wrapper.yml'
       - 'gymnasium_wrapper/**'
-      - 'tests/**'
+      - 'include/**'
+      - 'src/**'
+      - 'tests/test_gymnasium_wrapper.py'
       - 'CMakeLists.txt'
       - 'setup.py'
       - 'pyproject.toml'
@@ -14,7 +16,9 @@ on:
     paths:
       - '.github/workflows/test-gymnasium-wrapper.yml'
       - 'gymnasium_wrapper/**'
-      - 'tests/**'
+      - 'include/**'
+      - 'src/**'
+      - 'tests/test_gymnasium_wrapper.py'
       - 'CMakeLists.txt'
       - 'setup.py'
       - 'pyproject.toml'
@@ -54,4 +58,4 @@ jobs:
       run: python -c "import vizdoom"
 
     - name: Run tests
-      run: pytest tests/test_gymnasium_wrapper.py
+      run: pytest tests/test_gymnasium_wrapper.py -s


### PR DESCRIPTION
Because they take too long