### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test-windows-wheels.yml
+++ b/.github/workflows/build-and-test-windows-wheels.yml
@@ -26,6 +26,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Release


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/ViZDoom/security/code-scanning/3](https://github.com/Farama-Foundation/ViZDoom/security/code-scanning/3)

Add explicit `permissions` in `.github/workflows/build-and-test-windows-wheels.yml` at the workflow root so all jobs default to least privilege.  
Best fix without changing behavior: add

```yml
permissions:
  contents: read
```

right after the `on:` triggers block (before `env:`). This gives checkout/read access needed by build/test jobs while preventing unintended write scopes. The existing job-level override in `upload_pypi` (`id-token: write`) should remain unchanged so trusted publishing continues to work as designed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
