### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test-wheels.yml
+++ b/.github/workflows/build-and-test-wheels.yml
@@ -1,5 +1,8 @@
 name: Build and test Python wheels and make PyPI release
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/ViZDoom/security/code-scanning/2](https://github.com/Farama-Foundation/ViZDoom/security/code-scanning/2)

Add an explicit top-level `permissions` block in `.github/workflows/build-and-test-wheels.yml` so all jobs inherit least-privilege token scopes unless overridden.  
Best single fix without changing workflow behavior: insert at the root (after `name` or after `on`) a minimal read-only baseline:

- `contents: read`

This satisfies CodeQL’s requirement and documents intended privilege boundaries. No imports, methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
