### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -24,6 +24,9 @@ on:
       - 'pyproject.toml'
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   HOMEBREW_NO_AUTO_UPDATE: 1
   HOMEBREW_NO_INSTALL_CLEANUP: 1


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/ViZDoom/security/code-scanning/1](https://github.com/Farama-Foundation/ViZDoom/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is restricted to the minimum required scope.  
Best fix here: define it at the workflow root (applies to all jobs) with:

- `contents: read`

This preserves current functionality (checkout/build/test) while enforcing least privilege.  
Edit **`.github/workflows/build-and-test.yml`** by inserting the `permissions` block between `on:` triggers and `env:` (or any valid root-level location).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
