### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-gymnasium-wrapper.yml
+++ b/.github/workflows/test-gymnasium-wrapper.yml
@@ -24,6 +24,9 @@ on:
       - 'pyproject.toml'
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test_gymnasium_wrapper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/ViZDoom/security/code-scanning/7](https://github.com/Farama-Foundation/ViZDoom/security/code-scanning/7)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is scoped to least privilege.  
Best fix here: define workflow-level permissions right after `on:` (or after `name:`/trigger block) with:

- `contents: read`

This preserves existing behavior (checkout and test execution) while preventing implicit broader token access if repo/org defaults change. Only `.github/workflows/test-gymnasium-wrapper.yml` needs editing; no imports, methods, or dependencies are involved.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
