### PR TITLE
Potential fix for code scanning alert no. 43: Suspicious add with sizeof

### DIFF
--- a/src/vizdoom/src/memarena.cpp
+++ b/src/vizdoom/src/memarena.cpp
@@ -219,7 +219,7 @@ FMemArena::Block *FMemArena::AddBlock(size_t size)
 
 void FMemArena::Block::Reset()
 {
-	Avail = RoundPointer(this + sizeof(*this));
+	Avail = RoundPointer(this + 1);
 }
 
 //==========================================================================


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/ViZDoom/security/code-scanning/43](https://github.com/Farama-Foundation/ViZDoom/security/code-scanning/43)

The fix is to compute the first free address immediately after the `Block` header in **bytes**, not in `Block` elements.

Best minimal fix without changing functionality:
- In `src/vizdoom/src/memarena.cpp`, inside `FMemArena::Block::Reset()` (line 222 in the snippet), replace:
  - `Avail = RoundPointer(this + sizeof(*this));`
- With:
  - `Avail = RoundPointer(this + 1);`

Why this is best:
- `this + 1` on `Block*` correctly advances by exactly `sizeof(Block)` bytes (one header object).
- It preserves existing alignment handling by still calling `RoundPointer`.
- It is minimal, clear, and avoids introducing casts or extra helpers.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
