### PR TITLE
Potential fix for code scanning alert no. 52: Potential use after free

### DIFF
--- a/src/vizdoom/src/p_glnodes.cpp
+++ b/src/vizdoom/src/p_glnodes.cpp
@@ -1159,7 +1159,7 @@ static void CreateCachedNodes(MapData *map)
 	}
 
 	uLongf outlen = ZNodes.Size();
-	BYTE *compressed;
+	BYTE *compressed = NULL;
 	int offset = numlines * 8 + 12 + 16;
 	int r;
 	do
@@ -1169,6 +1169,7 @@ static void CreateCachedNodes(MapData *map)
 		if (r == Z_BUF_ERROR)
 		{
 			delete[] compressed;
+			compressed = NULL;
 			outlen += 1024;
 		}
 	} 


### PR DESCRIPTION
Potential fix for [https://github.com/Farama-Foundation/ViZDoom/security/code-scanning/52](https://github.com/Farama-Foundation/ViZDoom/security/code-scanning/52)

General fix: ensure a pointer is never left in a potentially dangling state after `delete[]`, and make loop allocation/retry logic explicit so post-loop uses are guaranteed to reference valid memory.

Best targeted fix here (in `src/vizdoom/src/p_glnodes.cpp`, around lines 1161–1176):
- Initialize `compressed` to `NULL`.
- After `delete[] compressed`, immediately set `compressed = NULL`.
- Keep retry loop behavior unchanged.

This preserves functionality while making ownership/lifetime explicit and eliminating the potential use-after-free path reported by CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
