### PR TITLE
fix: support GCC __BYTE_ORDER__ big-endian detection on s390x (IBM Z)

### DIFF
--- a/src/vizdoom/src/m_swap.h
+++ b/src/vizdoom/src/m_swap.h
@@ -77,7 +77,7 @@ inline unsigned int BigLong(unsigned int x)
 }
 
 #else
-#ifdef __BIG_ENDIAN__
+#if defined(__BIG_ENDIAN__) || (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 
 // Swap 16bit, that is, MSB and LSB byte.
 // No masking with 0xFF should be necessary. 
@@ -89,6 +89,12 @@ inline short LittleShort (short x)
 inline unsigned short LittleShort (unsigned short x)
 {
 	return (unsigned short)((x>>8) | (x<<8));
+}
+
+inline short LittleShort (int x)
+{
+	unsigned short s = (unsigned short)x;
+	return (short)((s>>8) | (s<<8));
 }
 
 // Swapping 32bit.
@@ -204,7 +210,7 @@ inline int GetBigInt(const unsigned char *foo)
 	return int((foo[0] << 24) | (foo[1] << 16) | (foo[2] << 8) | foo[3]);
 }
 #endif
-#ifdef __BIG_ENDIAN__
+#if defined(__BIG_ENDIAN__) || (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
 inline int GetNativeInt(const unsigned char *foo)
 {
 	return GetBigInt(foo);

--- a/src/vizdoom/tools/zipdir/zipdir.c
+++ b/src/vizdoom/tools/zipdir/zipdir.c
@@ -67,7 +67,7 @@
 #define FORCE_PACKED
 #endif
 
-#ifndef __BIG_ENDIAN__
+#if !defined(__BIG_ENDIAN__) && (__BYTE_ORDER__ != __ORDER_BIG_ENDIAN__)
 #define MAKE_ID(a,b,c,d)	((a)|((b)<<8)|((c)<<16)|((d)<<24))
 #define LittleShort(x)		(x)
 #define LittleLong(x)		(x)


### PR DESCRIPTION
VizDoom fails to build on s390x (IBM Z) Linux due to two separate big-endian issues.

GCC on s390x defines `__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__` but **never** defines `__BIG_ENDIAN__`. The codebase only checks `__BIG_ENDIAN__`, so all endianness guards are never activated — byte-swap functions silently become no-ops, corrupting ZIP and WAD data at runtime, and causing an ambiguous overload compile error in `p_acs.cpp`.

**Environment:**
- OS: Ubuntu 22.04 (s390x / IBM Z)
- Compiler: GCC 13.3.0
- Architecture: s390x (big-endian)

---

## Fix

### Issue 1 — `tools/zipdir/zipdir.c`

The little-endian no-op guard used `#ifndef __BIG_ENDIAN__`, which is never false on s390x with GCC.

```c
// Before
#ifndef __BIG_ENDIAN__

// After
#if !defined(__BIG_ENDIAN__) && (__BYTE_ORDER__ != __ORDER_BIG_ENDIAN__)
``` 

### Issue 2 — src/vizdoom/src/m_swap.h
Two #ifdef __BIG_ENDIAN__ guards never triggered on s390x, making all LittleShort/LittleLong functions no-ops.

```c
// Before
#ifdef __BIG_ENDIAN__

// After
#if defined(__BIG_ENDIAN__) || (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
``` 

Additionally, the generic big-endian block was missing a LittleShort(int) overload that already exists in the Apple-specific block. Its absence caused an ambiguous overload compile error in p_acs.cpp on s390x:
```c
inline short LittleShort (int x)
{
    unsigned short s = (unsigned short)x;
    return (short)((s>>8) | (s<<8));
}
``` 

---

### Testing
Built and tested on Ubuntu 22.04 s390x (IBM Z) with GCC 13.3.0:

Full build completes with zero errors and zero warnings
vizdoom.pk3 generated correctly (583 files)
VizDoom runs successfully on s390x

Fixes #710