### PR TITLE
Add Ubuntu ARM runner to the workflows

### DIFF
--- a/.github/workflows/build-and-test-wheels.yml
+++ b/.github/workflows/build-and-test-wheels.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15]
       fail-fast: false
 
     steps:
@@ -45,22 +45,25 @@ jobs:
           echo ${{ runner.os }}
           uname -p
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v4
-        with:
-          platforms: all
 
-      - name: Build manylinux wheels
+      - name: Build manylinux x86_64 wheels
         if: matrix.os == 'ubuntu-24.04'
         uses: pypa/cibuildwheel@v4.2.0
         env:
           # Configure cibuildwheel to build native archs, and some emulated ones
-          CIBW_ARCHS_LINUX: x86_64 aarch64
+          CIBW_ARCHS_LINUX: x86_64
+          CIBW_BUILD_VERBOSITY: 1
+      
+      - name: Build manylinux arm wheels
+        if: matrix.os == 'ubuntu-24.04'
+        uses: pypa/cibuildwheel@v4.2.0
+        env:
+          # Configure cibuildwheel to build native archs, and some emulated ones
+          CIBW_ARCHS_LINUX: aarch64
           CIBW_BUILD_VERBOSITY: 1
 
       - name: Build macOS Apple Silicon wheels
-        if: matrix.os == 'macos-14'
+        if: matrix.os == 'macos-15'
         uses: pypa/cibuildwheel@v4.2.0
         env:
           CIBW_ARCHS_MACOS: arm64
@@ -83,7 +86,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14, macos-15]
+        os: [ubuntu-24.04, macos-15, ubuntu-24.04-arm]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
 
@@ -123,17 +126,24 @@ jobs:
         run: sudo apt install -y libopenal-dev
 
       - name: Install macOS Apple Silicon wheel on ${{ matrix.os }}
-        if: matrix.os == 'macos-14' || matrix.os == 'macos-15'
+        if: matrix.os == 'macos-15'
         run: |
           export PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
           export WHEEL=$(ls dist/vizdoom*cp${PYTHON_VERSION}*macosx*arm64.whl)
           python -m pip install ${WHEEL}[test]
 
       - name: Install manylinux wheel on ${{ matrix.os }}
-        if: matrix.os == 'ubuntu-22.04' || matrix.os == 'ubuntu-24.04'
+        if: matrix.os == 'ubuntu-24.04'
         run: |
           export PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
           export WHEEL=$(ls dist/vizdoom*cp${PYTHON_VERSION}*manylinux*x86_64.whl)
+          python -m pip install ${WHEEL}[test]
+      
+      - name: Install manylinux wheel on ${{ matrix.os }}
+        if: matrix.os == 'ubuntu-24.04-arm'
+        run: |
+          export PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
+          export WHEEL=$(ls dist/vizdoom*cp${PYTHON_VERSION}*manylinux*aarch64.whl)
           python -m pip install ${WHEEL}[test]
 
       - name: Import check

--- a/.github/workflows/build-and-test-wheels.yml
+++ b/.github/workflows/build-and-test-wheels.yml
@@ -52,7 +52,7 @@ jobs:
           # Configure cibuildwheel to build native archs, and some emulated ones
           CIBW_ARCHS_LINUX: x86_64
           CIBW_BUILD_VERBOSITY: 1
-      
+
       - name: Build manylinux arm wheels
         if: matrix.os == 'ubuntu-24.04-arm'
         uses: pypa/cibuildwheel@v4.2.0
@@ -137,7 +137,7 @@ jobs:
           export PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
           export WHEEL=$(ls dist/vizdoom*cp${PYTHON_VERSION}*manylinux*x86_64.whl)
           python -m pip install ${WHEEL}[test]
-      
+
       - name: Install manylinux wheel on ${{ matrix.os }}
         if: matrix.os == 'ubuntu-24.04-arm'
         run: |

--- a/.github/workflows/build-and-test-wheels.yml
+++ b/.github/workflows/build-and-test-wheels.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-15, ubuntu-24.04-arm]
+        os: [ubuntu-26.04, ubuntu-24.04, ubuntu-24.04-arm, macos-15]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
 
@@ -132,7 +132,7 @@ jobs:
           python -m pip install ${WHEEL}[test]
 
       - name: Install manylinux wheel on ${{ matrix.os }}
-        if: matrix.os == 'ubuntu-24.04'
+        if: matrix.os == 'ubuntu-26.04' || matrix.os == 'ubuntu-24.04'
         run: |
           export PYTHON_VERSION=$(python -c "import sys; print(f'{sys.version_info.major}{sys.version_info.minor}')")
           export WHEEL=$(ls dist/vizdoom*cp${PYTHON_VERSION}*manylinux*x86_64.whl)

--- a/.github/workflows/build-and-test-wheels.yml
+++ b/.github/workflows/build-and-test-wheels.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-14]
       fail-fast: false
 
     steps:
@@ -45,7 +45,6 @@ jobs:
           echo ${{ runner.os }}
           uname -p
 
-
       - name: Build manylinux x86_64 wheels
         if: matrix.os == 'ubuntu-24.04'
         uses: pypa/cibuildwheel@v4.2.0
@@ -55,7 +54,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
       
       - name: Build manylinux arm wheels
-        if: matrix.os == 'ubuntu-24.04'
+        if: matrix.os == 'ubuntu-24.04-arm'
         uses: pypa/cibuildwheel@v4.2.0
         env:
           # Configure cibuildwheel to build native archs, and some emulated ones
@@ -63,7 +62,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 1
 
       - name: Build macOS Apple Silicon wheels
-        if: matrix.os == 'macos-15'
+        if: matrix.os == 'macos-14'
         uses: pypa/cibuildwheel@v4.2.0
         env:
           CIBW_ARCHS_MACOS: arm64

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
     name: Build and test on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-14]
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-14]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: true
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -37,7 +37,7 @@ jobs:
     name: Build and test on ${{ matrix.os }} with Python ${{ matrix.python-version }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-24.04-arm, macos-14]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macos-15]
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: true
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This PR adds `ubuntu-24.04-arm` runner to `build-and-test.yml` and `build-wheels.yml` replacing QEMU for building arm wheels.